### PR TITLE
fix initialization problem in random number generator

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>particle_filter</name>
-  <version>0.0.0</version>
+  <version>0.0.1</version>
   <description>This package provides a library for particle filters in ROS.</description>
 
   <maintainer email="2hartfil@informatik.uni-hamburg.de">Judith Hartfill</maintainer>

--- a/src/CRandomNumberGenerator.cpp
+++ b/src/CRandomNumberGenerator.cpp
@@ -27,6 +27,7 @@ CRandomNumberGenerator::~CRandomNumberGenerator() {}
 
 void CRandomNumberGenerator::init() {
     srand(time(0));
+    m_GaussianBufferFilled = false;
 }
 
 double CRandomNumberGenerator::getGaussian(double standardDeviation) const {


### PR DESCRIPTION
This pull request fixes an initialization problem in the random number generator: When `getGaussian` is called for the first time, the boolean `m_GaussianBufferFilled` contains random memory that is often evaluated to true, resulting in returning `m_GaussianBufferVariable` that is also not initialized and therefore contains random memory. This results in the problem that the first call to `getGaussian` returns garbage.