### PR TITLE
Add CI configuration and `.rdmanifest`

### DIFF
--- a/.rdmanifest
+++ b/.rdmanifest
@@ -1,0 +1,17 @@
+---
+# See http://doku.bit-bots.de/meta/manual/software/ci.html#make-package-resolvable-in-ci
+check-presence-script: '#!/bin/bash
+
+  test -d $BITBOTS_CATKIN_WORKSPACE/src/particle_filter'
+depends:
+- eigen_conversions
+- geometry_msgs
+- rosconsole
+- roscpp
+- std_msgs
+- visualization_msgs
+exec-path: particle_filter-master
+install-script: '#!/bin/bash
+
+  cp -r . $BITBOTS_CATKIN_WORKSPACE/src/particle_filter'
+uri: https://github.com/bit-bots/particle_filter/archive/refs/heads/master.tar.gz

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,7 @@
+@Library('bitbots_jenkins_library') import de.bitbots.jenkins.*;
+
+defineProperties()
+
+def pipeline = new BitbotsPipeline(this, env, currentBuild, scm)
+pipeline.configurePipelineForPackage(new PackagePipelineSettings(new PackageDefinition("particle_filter", ".")).withoutDocumentation().withoutPublishing())
+pipeline.execute()


### PR DESCRIPTION
This PR adds a Jenkinsfile to configure our CI to automatically build this package.
It also contains an `.rdmanifest` which is necessary for this package to be installable as a dependency through rosdep in CI.