### PR TITLE
use -Wall in particle filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(particle_filter)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+add_compile_options(-Wall -Werror -Wno-unused)
 
 find_package(catkin REQUIRED COMPONENTS
   roscpp
@@ -31,6 +32,7 @@ endif(MSVC90 OR MSVC10)
 
 else(OPENMP_FOUND)
 message (STATUS "OpenMP not found")
+add_compile_options(-Wno-unknown-pragmas)
 endif()
 
 if (MSVC)

--- a/include/particle_filter/Particle.h
+++ b/include/particle_filter/Particle.h
@@ -74,9 +74,9 @@ private:
 
 template <class StateType>
 Particle<StateType>::Particle(const StateType& state, double weight) :
+        is_explorer_(false),
         m_State(state),
-        m_Weight(weight),
-        is_explorer_(false) {}
+        m_Weight(weight) {}
 
 template <class StateType>
 Particle<StateType>::~Particle<StateType>() {}

--- a/include/particle_filter/ParticleFilter.hxx
+++ b/include/particle_filter/ParticleFilter.hxx
@@ -200,7 +200,7 @@ void ParticleFilter<StateType>::drift(geometry_msgs::Vector3 linear,
 
 template <class StateType>
 void ParticleFilter<StateType>::diffuse() {
-#pragma parallel for
+//#pragma omp parallel for
     for (unsigned int i = 0; i < m_NumParticles; i++) {
         m_MovementModel->diffuse(m_CurrentList[i]->m_State);
     }
@@ -215,7 +215,7 @@ void ParticleFilter<StateType>::measure() {
         //    not decay
     }
     double weight;
-#pragma parallel for
+//#pragma omp parallel for
     for (unsigned int i = 0; i < m_NumParticles; i++) {
         // apply observation model
 

--- a/include/particle_filter/gaussian_mixture_model.h
+++ b/include/particle_filter/gaussian_mixture_model.h
@@ -128,14 +128,14 @@ public:
     }
     inline const std::vector<Eigen::VectorXd> gaussianMeans() const {
         std::vector<Eigen::VectorXd> means(gaussian_vec_.size());
-        for (int g = 0; g < gaussian_vec_.size(); ++g) {
+        for (size_t g = 0; g < gaussian_vec_.size(); ++g) {
             means.at(g) = gaussian_vec_.at(g).mean();
         }
         return means;
     }
     inline const std::vector<Eigen::MatrixXd> gaussianCovariances() const {
         std::vector<Eigen::MatrixXd> covs(gaussian_vec_.size());
-        for (int g = 0; g < gaussian_vec_.size(); ++g) {
+        for (size_t g = 0; g < gaussian_vec_.size(); ++g) {
             covs.at(g) = gaussian_vec_.at(g).covariance();
         }
         return covs;

--- a/src/gaussian_mixture_model.cpp
+++ b/src/gaussian_mixture_model.cpp
@@ -155,7 +155,7 @@ void GaussianMixtureModel::maximization(const Eigen::MatrixXd& dataset) {
 
         omp_destroy_lock(&lck);
 
-        for (int t = 0; t < thread_covariance.size(); ++t) {
+        for (size_t t = 0; t < thread_covariance.size(); ++t) {
             covariance += thread_covariance.at(t);
         }
 

--- a/src/gmm_classifier.cpp
+++ b/src/gmm_classifier.cpp
@@ -52,7 +52,7 @@ void GMMClassifier::train(const Eigen::MatrixXd& dataset,
 
         int class_data_idx = 0;
 
-        for (int data_idx = 0; data_idx < labels.size(); ++data_idx) {
+        for (long data_idx = 0; data_idx < labels.size(); ++data_idx) {
             if (labels(data_idx) == *it) {
                 class_data.row(class_data_idx++) = training_data.row(data_idx);
             }
@@ -72,7 +72,6 @@ void GMMClassifier::train(const Eigen::MatrixXd& dataset,
             num_components = gmm_components;
         }
 
-#pragma parallel for
         for (int c = num_components; c <= gmm_components; ++c) {
             std::cout << "\t\t\t\tUsing " << c << " GMM components"
                       << std::endl;
@@ -86,7 +85,7 @@ void GMMClassifier::train(const Eigen::MatrixXd& dataset,
 
             try {
                 model->expectationMaximization(class_data);
-            } catch (std::runtime_error e) {
+            } catch (std::runtime_error &e) {
                 std::cout << "\t\t\t\t" << c << " components are not usable"
                           << std::endl;
                 break;
@@ -137,7 +136,7 @@ std::vector<int> GMMClassifier::predict(const Eigen::MatrixXd& dataset) const {
         bool first = true;
         double log_likelihood = 0.0;
 
-        for (int k = 0; k < gmm_vec_.size(); ++k) {
+        for (size_t k = 0; k < gmm_vec_.size(); ++k) {
             if (gmm_vec_[k] == nullptr) {
                 continue;
             }
@@ -192,7 +191,7 @@ void GMMClassifier::save(const std::string filename) {
     int cols = 0;
     std::vector<Eigen::MatrixXd> gmm_models;
 
-    for (int k = 0; k < gmm_vec_.size(); ++k) {
+    for (size_t k = 0; k < gmm_vec_.size(); ++k) {
         if (gmm_vec_[k] == nullptr) {
             continue;
         }
@@ -216,7 +215,7 @@ void GMMClassifier::save(const std::string filename) {
 
     int idx = 4;
 
-    for (int k = 0; k < gmm_vec_.size(); ++k) {
+    for (size_t k = 0; k < gmm_vec_.size(); ++k) {
         if (gmm_vec_[k] == nullptr) {
             continue;
         }

--- a/src/gmm_regressor.cpp
+++ b/src/gmm_regressor.cpp
@@ -36,7 +36,6 @@ void GMMRegressor::train(const Eigen::MatrixXd& dataset,
         num_components = gmm_components;
     }
 
-#pragma parallel for
     for (int c = num_components; c <= gmm_components; ++c) {
         std::cout << "\t\t\t\tUsing " << c << " GMM components" << std::endl;
 
@@ -48,7 +47,7 @@ void GMMRegressor::train(const Eigen::MatrixXd& dataset,
 
         try {
             model->expectationMaximization(dataset);
-        } catch (std::runtime_error e) {
+        } catch (std::runtime_error &e) {
             std::cout << "\t\t\t\t" << c << " components are not usable"
                       << std::endl;
             break;


### PR DESCRIPTION
This adds -Wall to the particle filter, similar to bit-bots/bitbots_motion#256.
Concerning the `#pragma`s, there were some instances of `#pragma parallel for` which is not the OpenMP pragma (that is `#pragma omp parallel for`) and is normally ignored by the compiler, but yields an error now.
I removed the pragma where it cannot be used (for loops with `break`) and commented it out where it could be used, therefore this should not change the current behavior.