### PR TITLE
Fix resampling and normalization

### DIFF
--- a/include/particle_filter/ImportanceResampling.h
+++ b/include/particle_filter/ImportanceResampling.h
@@ -58,8 +58,8 @@ protected:
     CRandomNumberGenerator m_RNG;
 
 private:
-    bool reset_weights_;
-    double particle_reset_weight_;
+    bool reset_weights_ = true;
+    double particle_reset_weight_ = 0.01;
 };
 
 

--- a/include/particle_filter/Particle.h
+++ b/include/particle_filter/Particle.h
@@ -47,15 +47,26 @@ public:
     inline void setState(const StateType& newState);
 
     /**
-     * @return the weight
+     * @return the normalized weight
      */
     inline double getWeight() const;
+
+    /**
+     * @return the raw weight
+     */
+    inline double getWeightUnnormalized() const;
 
     /**
      * Sets a new weight
      * @param newWeight the new weight
      */
     inline void setWeight(double newWeight);
+
+    /**
+     * Sets the normalization factor
+     * @param newWeight the new weight
+     */
+    inline void setNormalization(double normalization);
 
     bool is_explorer_;
 
@@ -70,6 +81,9 @@ private:
 
     // Stores the importance factor (=weight) of the particle.
     double m_Weight;
+
+    // Stores the normalization
+    double m_normalization = 1;
 };
 
 template <class StateType>
@@ -93,12 +107,22 @@ void Particle<StateType>::setState(const StateType& newState) {
 
 template <class StateType>
 double Particle<StateType>::getWeight() const {
+    return m_Weight * m_normalization;
+}
+
+template <class StateType>
+double Particle<StateType>::getWeightUnnormalized() const {
     return m_Weight;
 }
 
 template <class StateType>
 void Particle<StateType>::setWeight(double newWeight) {
     m_Weight = newWeight;
+}
+
+template <class StateType>
+void Particle<StateType>::setNormalization(double normalization) {
+    m_normalization = normalization;
 }
 }  // namespace particle_filter
 

--- a/include/particle_filter/ParticleFilter.hxx
+++ b/include/particle_filter/ParticleFilter.hxx
@@ -188,6 +188,11 @@ void ParticleFilter<StateType>::resample() {
     m_CurrentList.swap(m_LastList);
     // call resampling strategy
     m_ResamplingStrategy->resample(m_LastList, m_CurrentList);
+
+    for (ConstParticleIterator iter = m_CurrentList.begin(); iter != m_CurrentList.end();
+                ++iter) {
+        (*iter)->setWeight(.1);
+    }
 }
 
 

--- a/include/particle_filter/ParticleFilter.hxx
+++ b/include/particle_filter/ParticleFilter.hxx
@@ -154,36 +154,9 @@ void ParticleFilter<StateType>::sort() {
             CompareParticleWeights<StateType>());
 }
 
-template <class StateType>
-void ParticleFilter<StateType>::normalize() {
-    double weightSum = 0.0;
-    ConstParticleIterator iter;
-    for (iter = m_CurrentList.begin(); iter != m_CurrentList.end(); ++iter) {
-        weightSum += (*iter)->getWeight();
-    }
-    // only normalize if weightSum is big enough to devide
-    if (weightSum > m_NumParticles * std::numeric_limits<double>::epsilon()) {
-        double factor = 1.0 / weightSum;
-        for (iter = m_CurrentList.begin(); iter != m_CurrentList.end();
-                ++iter) {
-            double newWeight = (*iter)->getWeight() * factor;
-            (*iter)->setWeight(newWeight);
-        }
-    } else {
-        // std::cerr << "WARNING: ParticleFilter::normalize(): Particle weights
-        // *very* small!" << std::endl;
-        ROS_WARN_STREAM(
-                "The particle weights got extremely small. \nResetting them all to .8");
-        for (iter = m_CurrentList.begin(); iter != m_CurrentList.end();
-                ++iter) {
-            (*iter)->setWeight(.8);
-        }
-    }
-}
 
 template <class StateType>
 void ParticleFilter<StateType>::resample() {
-    normalize();
     // swap lists
     m_CurrentList.swap(m_LastList);
     // call resampling strategy
@@ -220,18 +193,17 @@ void ParticleFilter<StateType>::measure() {
         //    currently, this results in a problem, as the particle weight does
         //    not decay
     }
-    double weight;
+    double weight, weights_sum = 0;
 #pragma parallel for
-    for (unsigned int i = 0; i < m_NumParticles; i++) {
+    for (size_t i = 0; i < m_NumParticles; i++) {
         // apply observation model
 
         // accumulate the weight when it is defined in the observation model
         if (m_ObservationModel->accumulate_weights_) {
-            weight = m_CurrentList[i]->getWeight();
+            weight = m_CurrentList[i]->getWeightUnnormalized();
         } else {
             weight = 0;
         }
-
 
         // set explorer particle weight to minimal value if there are no
         // measurements available to reduce noise
@@ -242,8 +214,14 @@ void ParticleFilter<StateType>::measure() {
             weight += m_ObservationModel->measure(m_CurrentList[i]->getState());
         }
         m_CurrentList[i]->setWeight(weight);
+        // Update the weight sum
+        weights_sum += weight;
     }
-    // after measurement we have to re-sort and normalize the particles
+#pragma parallel for
+    for (size_t i = 0; i < m_NumParticles; i++) {
+        m_CurrentList[i]->setNormalization(1.0/weights_sum);
+    }
+    // re-sort the particles
     sort();
 }
 

--- a/include/particle_filter/ParticleFilter.hxx
+++ b/include/particle_filter/ParticleFilter.hxx
@@ -183,6 +183,7 @@ void ParticleFilter<StateType>::normalize() {
 
 template <class StateType>
 void ParticleFilter<StateType>::resample() {
+    normalize();
     // swap lists
     m_CurrentList.swap(m_LastList);
     // call resampling strategy
@@ -239,7 +240,6 @@ void ParticleFilter<StateType>::measure() {
     }
     // after measurement we have to re-sort and normalize the particles
     sort();
-    normalize();
 }
 
 template <class StateType>

--- a/include/particle_filter/ParticleFilter.hxx
+++ b/include/particle_filter/ParticleFilter.hxx
@@ -161,11 +161,6 @@ void ParticleFilter<StateType>::resample() {
     m_CurrentList.swap(m_LastList);
     // call resampling strategy
     m_ResamplingStrategy->resample(m_LastList, m_CurrentList);
-
-    for (ConstParticleIterator iter = m_CurrentList.begin(); iter != m_CurrentList.end();
-                ++iter) {
-        (*iter)->setWeight(.1);
-    }
 }
 
 

--- a/include/particle_filter/ParticleFilter.hxx
+++ b/include/particle_filter/ParticleFilter.hxx
@@ -189,7 +189,7 @@ void ParticleFilter<StateType>::measure() {
         //    not decay
     }
     double weight, weights_sum = 0;
-#pragma parallel for
+//#pragma omp parallel for
     for (size_t i = 0; i < m_NumParticles; i++) {
         // apply observation model
 
@@ -212,7 +212,7 @@ void ParticleFilter<StateType>::measure() {
         // Update the weight sum
         weights_sum += weight;
     }
-#pragma parallel for
+//#pragma omp parallel for
     for (size_t i = 0; i < m_NumParticles; i++) {
         m_CurrentList[i]->setNormalization(1.0/weights_sum);
     }


### PR DESCRIPTION
* Only does the normalization once before the resampling. Otherwise old values are accounted for too much or too low in the accumulation. The current fix might provide the non-resampling functions with non-normalized data. We have to find a way to mitigate this. Until now I had no Ideas other than recalculating the normalization if it is needed or adding a secondary copy of the particles which gets overwritten with the non-normalized accumulation and normalized after each measurement.
* Resets the particle weights after the resampling