### PR TITLE
include dependencies as system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ set(CODE_LIBRARIES)
 
 add_library(${PROJECT_NAME} ${SOURCES})
 
-ament_target_dependencies(${PROJECT_NAME}
+ament_target_dependencies(${PROJECT_NAME} SYSTEM
     Eigen3
     geometry_msgs
     rclcpp


### PR DESCRIPTION
Should address https://github.com/bit-bots/particle_filter/issues/17

To avoid warnings from Eigen-internal headers. You might as well split includes into ROS2-based and independent to only include the latter as `SYSTEM`, but then again your ROS2 dependencies are so basic that I don't think it is necessary.

@jaagut